### PR TITLE
Add shebang for Python3

### DIFF
--- a/extended-ssrf-search.py
+++ b/extended-ssrf-search.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # -*- coding: utf-8 -*-
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Just added a simple a Shebang 🙅🏻‍♂️

```
A shebang line defines where the interpreter is located. In this case, the python3 interpreter is located in /usr/bin/python3. A shebang line could also be a bash, ruby, perl or any other scripting languages' interpreter, for example: #!/bin/bash.
```